### PR TITLE
Patch to not mangle absolute URLs when parsing Selenium 1 HTML suites

### DIFF
--- a/seleniumbuilder/chrome/content/html/js/builder/selenium1/adapter.js
+++ b/seleniumbuilder/chrome/content/html/js/builder/selenium1/adapter.js
@@ -338,9 +338,11 @@ builder.selenium1.adapter.convertTestCaseToScript = function(testCase, originalF
       }
     }
     try {
-      // Internally we don't have base URLs, so we have to put them straight in here.
+      // Internally we don't have base URLs, so we have to put them straight in here if the provided URL isn't already absolute.
       if (stepType == builder.selenium1.stepTypes.open) {
-        if (params[0].startsWith("/") && endsWith(baseURL, "/")) {
+        if (params[0].match('^(http|https)://')) {
+          // leave already absolute params[0] alone
+        } else if (params[0].startsWith("/") && endsWith(baseURL, "/")) {
           params[0] = baseURL + params[0].substring(1);
         } else {
           params[0] = baseURL + params[0];


### PR DESCRIPTION
As per http://release.seleniumhq.org/selenium-core/1.0.1/reference.html the Selenium RC open() command supports either a relative or absolute URL, but code in selenium1/adapter.js prefixes all open() params with baseURL, which leads to things like http://example.com/http://example.com/foo, which isn't ideal.

In our cases we make use of variables for the domain, eg http://${mobile_domain}/foo, where we store the variables in an init case of the HTML suite, so we need to be able to open absolute links.

This also fixes round-tripping absolute URLs, which can be entered by editing the target via the UI, but when exported and reimported they get double-prefixed.
