### PR TITLE
Fix potential NPE in seinterpreter eval function

### DIFF
--- a/tools/seinterpreter/src/com/sebuilder/interpreter/steptype/Eval.java
+++ b/tools/seinterpreter/src/com/sebuilder/interpreter/steptype/Eval.java
@@ -22,11 +22,11 @@ import com.sebuilder.interpreter.TestRun;
 public class Eval implements Getter {
 	@Override
 	public String get(TestRun ctx) {
-        Object scriptRes=ctx.driver().executeScript(ctx.string("script"));
+		Object scriptRes=ctx.driver().executeScript(ctx.string("script"));
 		if(scriptRes != null)
-            return scriptRes.toString();
-        else
-            return null;
+			return scriptRes.toString();
+		else
+			return null;
 	}
 
 	@Override


### PR DESCRIPTION
According to the Selenium javadoc: http://selenium.googlecode.com/git/docs/api/java/org/openqa/selenium/remote/RemoteWebDriver.html RemoteWebDriver.eval() can return null if the evaluated javascript does not contain a return statement.  However the current seinterpreter always calls the .toString method on the eval result without doing a null check first, which will result in a NullPointerException when the result is null.  I simply added in a null check here to make sure this doesn't happen.
