### PR TITLE
fix for builder.Url.hostname regex

### DIFF
--- a/seleniumbuilder/chrome/content/html/js/builder/url.js
+++ b/seleniumbuilder/chrome/content/html/js/builder/url.js
@@ -25,7 +25,7 @@ builder.Url.prototype = {
    * Example: http://www.foo.com:8000/bar -> www.foo.com
    */
   hostname: function () {
-    return this.base ? this.base.replace(/^.*:\/\/([^:\/\?#]*)$/, "$1") : null;
+    return this.base ? this.base.replace(/^.*:\/\/([^:\/\?#]+).*$/i, "$1") : null;
   },
   
   /**


### PR DESCRIPTION
Quick fix to the builder.Url.hostname regex.

Pre-change behavior:

```
>>> new builder.Url('http://www.shopping.hp.com/en_US/home-office/-/products/Laptops/Laptops').hostname();
"http://www.shopping.hp.com/en_US/home-office/-/products/Laptops/Laptops"
```

Post-change behavior:

```
>>> new builder.Url('http://www.shopping.hp.com/en_US/home-office/-/products/Laptops/Laptops').hostname();
"www.shopping.hp.com"
```
