### PR TITLE
Fixed bug that prevented text present from ever returning true

### DIFF
--- a/tools/seinterpreter/src/com/sebuilder/interpreter/steptype/TextPresent.java
+++ b/tools/seinterpreter/src/com/sebuilder/interpreter/steptype/TextPresent.java
@@ -22,7 +22,9 @@ import com.sebuilder.interpreter.TestRun;
 public class TextPresent implements Getter {
 	@Override
 	public String get(TestRun ctx) {
-		return "" + ctx.driver().findElementByTagName("html").getText().contains(ctx.string("text"));
+		String param=ctx.string(cmpParamName());
+		return ctx.driver().findElementByTagName("html").getText().contains(param) ?
+                	param : null;
 	}
 
 	@Override


### PR DESCRIPTION
The current TextPresent step has a bug that prevents it from ever returning true(unless you are actually looking for the text true...)  The problem is it returns true/false like a step that doesn't have a parameter, but it does have a parameter.  Therefore what happens is that the assert instead of parsing the boolean actually tries to compare true/false to the parameter, which will always end up being false regardless of the text on the page.  This fix simply changes the logic to return the parameter when it matches, or null when it doesn't.  That way the assert will pick it up.
