### PR TITLE
Make inputs panel scrollable

### DIFF
--- a/seleniumbuilder/chrome/content/html/css/gui.css
+++ b/seleniumbuilder/chrome/content/html/css/gui.css
@@ -395,6 +395,8 @@ h1 {
   z-index:5;
   top:1em;
   right:2em;
+  height: 100%;
+  overflow: scroll;
 }
 
 .dialog {


### PR DESCRIPTION
Allow the _inputs_-panel to scroll.

Closes #190
