### PR TITLE
fixed eval step type and updated pom

### DIFF
--- a/tools/seinterpreter/pom.xml
+++ b/tools/seinterpreter/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>sebuilder-interpreter</artifactId>
     <groupId>com.saucelabs</groupId>
-    <version>1.0.1</version>
+    <version>1.0.5</version>
     <packaging>jar</packaging>
     <name>sebuilder-interpreter</name>
     <description></description>

--- a/tools/seinterpreter/src/com/sebuilder/interpreter/steptype/Eval.java
+++ b/tools/seinterpreter/src/com/sebuilder/interpreter/steptype/Eval.java
@@ -27,5 +27,5 @@ public class Eval implements Getter {
 	}
 
 	@Override
-	public String cmpParamName() { return "title"; }
+	public String cmpParamName() { return "value"; }
 }


### PR DESCRIPTION
fixes #215

verify, assert, and wait for would fail using se-interpreter to run json tests because the se-builder plugin outputs json such that: 

```
{
  "type": "assertEval",
  "script": "return true;",
  "value": "true"
}
```

woulds be an assertEvaluation. But the interpreter was looking for the comparator param to be called "title", which resulted in an error.

Also, I updated the POM to show where this build is in relation to the latest build hosted at the sauce labs maven repo:
 http://repository-saucelabs.forge.cloudbees.com/release/com/saucelabs/sebuilder-interpreter/
