### PR TITLE
Fix for locating frames by name

### DIFF
--- a/seleniumbuilder/components/driver_component.js
+++ b/seleniumbuilder/components/driver_component.js
@@ -6608,11 +6608,11 @@ FirefoxDriver.prototype.switchToFrame = function(a, b) {
       fxdriver.Logger.dumpn("Switching to frame with name or ID: " + b.id);
       for(var f, d = c.frames.length, g = 0;g < d;g++) {
         var h = c.frames[g], j = h.frameElement;
-        if(j.name == b.id) {
+        if(j && j.name == b.id) {
           e = h;
           break
         }else {
-          !f && j.id == b.id && (f = h)
+          !f && j && j.id == b.id && (f = h)
         }
       }
       !e && f && (e = f)


### PR DESCRIPTION
If a site has certain frames, the iteration can error out early because j is null. By first checking that j isn't null or undefined, we avoid breaking this.
