### PR TITLE
Change Travis CI badge to use SVG format

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         <a href="https://github.com/sebuilder/se-builder/wiki">Documentation</a>
       </li>
       <li>
-        <a href="http://travis-ci.org/sebuilder/se-builder"><img src="https://secure.travis-ci.org/sebuilder/se-builder.png" alt="Build Status"></a>
+        <a href="http://travis-ci.org/sebuilder/se-builder"><img src="https://secure.travis-ci.org/sebuilder/se-builder.svg" alt="Build Status"></a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Travis CI badge changed to use SVG (instead of PNG) format to look nice on Retina displays.
