### PR TITLE
Use version range for selenium-java dependency

### DIFF
--- a/tools/seinterpreter/pom.xml
+++ b/tools/seinterpreter/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>LATEST</version>
+            <version>[2.0,3.0)</version>
         </dependency>
         <dependency>
         	  <groupId>net.sf.opencsv</groupId>


### PR DESCRIPTION
The version "LATEST" does not work everywhere and is not supported by maven 3. Instead you should use a version range. The range [2.0,3.0) means every version >= 2.0 and < 3.0 is ok.

Also see
* https://cwiki.apache.org/confluence/display/MAVEN/Maven+3.x+Compatibility+Notes#Maven3.xCompatibilityNotes-PluginMetaversionResolution
* https://support.sonatype.com/entries/23778606-Why-are-the-latest-and-release-tags-in-maven-metadata-xml-not-being-updated-after-deploying-artifact
* http://books.sonatype.com/mvnref-book/reference/pom-relationships-sect-project-dependencies.html#pom-relationships-sect-version-ranges
* http://articles.javatalks.ru/articles/32

Another option would be to use the maven versions plugin http://mojo.codehaus.org/versions-maven-plugin/