### PR TITLE
Build sources and javadoc jar

### DIFF
--- a/tools/seinterpreter/pom.xml
+++ b/tools/seinterpreter/pom.xml
@@ -74,6 +74,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
@@ -82,6 +83,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                 </configuration>
@@ -103,6 +105,38 @@
                 <artifactId>maven-scm-plugin</artifactId>
                 <version>1.3</version>
             </plugin>
+            <!-- Package source to JAR to upload to repo-->
+             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <!-- Restrict execution of source compilation to install or deploy. -->
+                        <!-- The default is package. -->
+                        <phase>install</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+             </plugin>
+             <!-- Package JavaDocs to JAR to upload to repo -->
+             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <!-- Restrict execution of source compilation to install -->
+                        <phase>install</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+             </plugin>
         </plugins>
         <extensions>
             <extension>


### PR DESCRIPTION
Build and deploy the sources and javadoc jar for other developers. This also
(potentially) allows Eclipse and IntelliJ to find the sources automatically.
Also add some version tags to the plugins to fix maven 3 warnings.