### PR TITLE
fix to enable url with file:/// prefix

### DIFF
--- a/seleniumbuilder/chrome/content/html/js/builder/url.js
+++ b/seleniumbuilder/chrome/content/html/js/builder/url.js
@@ -17,7 +17,7 @@ builder.Url.prototype = {
    * Example: http://www.foo.com:8000/bar -> http://www.foo.com:8000
    */
   server: function () {
-    return this.base ? this.base.replace(/^([a-z]*:\/\/[^\/\?#]+).*$/i, "$1") : null;
+    return this.base ? this.base.replace(/^([a-z]*:\/\/\/?[^\/\?#]+).*$/i, "$1") : null;
   },
 
   /**


### PR DESCRIPTION
with the old regex starting the recording from an url as 'file:///c:/mypage.html' will navigate to  'file:///c:/mypage.html/' breaking all the relative references within the html page.

this fix enable builder.Url.href() to be correctly resolved when using the file:/// schema prefix