### PR TITLE
bugfix to correctly calculate on windows os the names of the scripts

### DIFF
--- a/seleniumbuilder/chrome/content/html/js/builder/suite2.js
+++ b/seleniumbuilder/chrome/content/html/js/builder/suite2.js
@@ -101,7 +101,10 @@ builder.suite.getScriptNames = function() {
     var script = builder.suite.scripts[i];
     var name = "[" + _t('untitled_script') + " " + (i + 1) + "]";
     if (script.path) {
-      name = script.path.path.split("/");
+      if (script.path.path.indexOf("/") > - 1) //unix path
+        name = script.path.path.split("/");
+      else //windows path
+        name = script.path.path.split("\\");
       name = name[name.length - 1].split(".")[0];
     }
     if (script.exportpath) {


### PR DESCRIPTION
on windows the directory separator path is '\', not '/', so the match fails and the complete path of the script is used as name when enumerating the scripts names under the suite menu item