### PR TITLE
Use target node id, class, label for XPath locator

### DIFF
--- a/seleniumbuilder/chrome/content/html/js/builder/locator.js
+++ b/seleniumbuilder/chrome/content/html/js/builder/locator.js
@@ -397,37 +397,42 @@ function getHtmlXPath(node) {
   if (nodeName === "html") {
     return "//html";
   }
-  var parent = getMyXPath(node.parentNode, window.bridge.getRecordingWindow().document);
+  var myPath = getMyXPath(node, window.bridge.getRecordingWindow().document);
 
-  if (parent.indexOf("']") > -1) {
+  var index = myPath.indexOf("']");
+  if (index > -1 && index < myPath.length - 2) {
 
+    // contains '], but it is not last characters.
     var text = node.textContent;
     // Escape ' characters.
     text = text.replace(/[']/gm, "&quot;");
 
     // Attempt to key on the text content of the node for extra precision.
     if (text && text.length < 30) {
-      var win = window.bridge.getRecordingWindow();
-      var attempt = parent.substr(0, parent.indexOf("']") + 2) + "//" + nodeName;
-      // If the text contains whitespace characters that aren't spaces, we convert any
-      // runs of whitespace into single spaces and trim off the ends, then use the
-      // XPath normalize-space command to ensure it will get matched correctly. Otherwise
-      // links with eg newlines in them won't work. 
-      if (hasNonstandardWhitespace(text)) {
-        attempt = attempt + "[normalize-space(.)='" +
-            builder.normalizeWhitespace(text) + "']";
-      } else {
-        // (But if we can get away without it, do so!)
-        attempt = attempt + "[.='" + text + "']";
-      }
-      // Check this actually works. 
-      if (new MozillaBrowserBot(win).findElementBy("xpath", attempt, win.document, win) === node) {
-        return attempt;
+      var parent = getMyXPath(node.parentNode, window.bridge.getRecordingWindow().document);
+      if (parent.indexOf("']") > -1) {
+        var win = window.bridge.getRecordingWindow();
+        var attempt = parent.substr(0, parent.indexOf("']") + 2) + "//" + nodeName;
+        // If the text contains whitespace characters that aren't spaces, we convert any
+        // runs of whitespace into single spaces and trim off the ends, then use the
+        // XPath normalize-space command to ensure it will get matched correctly. Otherwise
+        // links with eg newlines in them won't work. 
+        if (hasNonstandardWhitespace(text)) {
+          attempt = attempt + "[normalize-space(.)='" +
+              builder.normalizeWhitespace(text) + "']";
+        } else {
+          // (But if we can get away without it, do so!)
+          attempt = attempt + "[.='" + text + "']";
+        }
+        // Check this actually works. 
+        if (new MozillaBrowserBot(win).findElementBy("xpath", attempt, win.document, win) === node) {
+          return attempt;
+        }
       }
     }
   }
 
-  return parent + "/" + getChildSelector(node);
+  return myPath;
 }
 
 /** Whether the given text has non-space (0x20) whitespace). */


### PR DESCRIPTION
Id or name value of select element is not used in the recorded option element locator for setElementSelected command.
For example, when selecting 'item 1' in the following HTML, the recorded locator is such as `form[@id = 'main']/select[1]//option[1]`.

```html
<form id="main">
  <select id="sample">
    <option value="1">item 1</option>
    <option value="2">item 2</option>
  </select>
</form>
```

I think locator `select[@id = 'sample']//option[1]` would be better.

This behaviour is caused by the getHtmlXPath method in locator.js, which does not use the id, unique class, label value of the target node, and uses only the ones for its parent nodes. I think it is better to use id, unique class, label value of the target node in xpath. This is less fragile locator.

If both `form[@id = 'main']/select[1]` and `select[@id = 'sample']` should be recorded as XPath locator or suggested alternatives, please let me know, and I will fix this pull request.