### PR TITLE
Disable manually installed plugin uninstallation.

### DIFF
--- a/seleniumbuilder/chrome/content/html/js/builder/views/plugins.js
+++ b/seleniumbuilder/chrome/content/html/js/builder/views/plugins.js
@@ -128,7 +128,8 @@ builder.views.plugins.updatePluginEntry = function(info) {
   jQuery('#' + info.identifier + '-status').text(builder.views.plugins.getStatus(info));
   
   jQuery('#' + info.identifier + '-install-and-reboot').toggle(info.installState == builder.plugins.NOT_INSTALLED && !builder.plugins.isPluginTooNew(info) && !builder.plugins.isPluginTooOld(info));
-  jQuery('#' + info.identifier + '-uninstall-and-reboot').toggle(info.installState == builder.plugins.INSTALLED);
+  // no repository info plugin has been added to plugin directory manually, and must be uninstalled also manually
+  jQuery('#' + info.identifier + '-uninstall-and-reboot').toggle(info.installState == builder.plugins.INSTALLED && info.repositoryInfo != null);
   jQuery('#' + info.identifier + '-update-and-reboot').toggle(info.installState == builder.plugins.INSTALLED && builder.plugins.isUpdateable(info) && !builder.plugins.isPluginTooNew(info) && !builder.plugins.isPluginTooOld(info));
   jQuery('#' + info.identifier + '-enable-and-reboot').toggle(info.installState == builder.plugins.INSTALLED && (info.enabledState == builder.plugins.DISABLED || info.enabledState == builder.plugins.TO_DISABLE));
   jQuery('#' + info.identifier + '-disable-and-reboot').toggle(info.installState == builder.plugins.INSTALLED && (info.enabledState == builder.plugins.ENABLED || info.enabledState == builder.plugins.TO_ENABLE));


### PR DESCRIPTION
Since [this article](https://github.com/SeleniumBuilder/se-builder/wiki/Plugin-Developer-Documentation#installing-and-supplying-plugins) says 'Plugins can be installed simply by dropping them into the <your Firefox profile>/SeBuilder/plugins directory', I use my in-house selenium builder plugin by manually adding it to the SeBuilder plugin directory.

But when plugin user uninstall this plugin from 'Management plugins' page and then install it again by manually adding it to the SeBuilder plugin directory, 'Management plugins' page is not correctly shown because of javascript error.

This problem is caused as below:

- NOT_INSTALLED state is inserted to plugins.sqlite when unininstalling the plugin
- After then, when user manually adds the plugin files again, isPluginTooNew method is called [here](https://github.com/SeleniumBuilder/se-builder/blob/master/seleniumbuilder/chrome/content/html/js/builder/views/plugins.js#L61) and null reference error is thrown [here](https://github.com/SeleniumBuilder/se-builder/blob/master/seleniumbuilder/chrome/content/html/js/builder/plugins.js#L95) since info.repositoryInfo is null.

I considered the following 3 different ideas and adopted the 1st one.

1. Uninstallation from 'Management plugins' page is enabled only for the plugin installed from the central repository. Plugins installed by manually adding them into the plugin directory must be uninstalled by manually removing them from the plugin direcotry. This approach works well.
2. Deleteing plugins.sqlite record when uninstalling a plugin which does not have the repositoryInfo. To implement this, builder.plugins.performInstall method must have access to info.repositoryInfo, but this is a little difficult..
3. Call builder.plugins.isUpdateable before each builder.plugins.isPluginTooNew and builder.plugins.isPluginTooOld call. Even after adding this check, the plugin re-installation process still does not work well..