### PR TITLE
bugfix to support the update of a frame' source

### DIFF
--- a/seleniumbuilder/chrome/content/html/js/builder/selenium2/recorder.js
+++ b/seleniumbuilder/chrome/content/html/js/builder/selenium2/recorder.js
@@ -508,6 +508,12 @@ builder.selenium2.Recorder.prototype = {
     // Remember that this frame has been bound to.
     this.bound.push(frame);
     
+    var bound = this.bound;
+    jQuery(frame).one('unload', function() {
+        var index = bound.indexOf(this);
+        bound.splice(index, 1);
+    });
+    
     // Turns out there are cases where people are canceling click on purpose, so I am manually
     // going to attach click listeners to all links.
     var links = frame.document.getElementsByTagName('a');


### PR DESCRIPTION
when a frame is unload we remove it from the 'bound' array so we can rebind it later to record the new content